### PR TITLE
fix(workflow): goreleaser fix for hub push

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,9 +11,7 @@ builds:
       - linux
       - darwin
     goarch:
-      - "386"
       - amd64
-      - arm
       - arm64
     ldflags:
       - -s -w
@@ -25,9 +23,40 @@ changelog:
       - Merge branch
       - go mod tidy
 dockers:
-- 
-  image_templates: 
-  - "ministryofjustice/cloud-platform-po-linter:{{ .Tag}}"
-  - "ministryofjustice/cloud-platform-po-linter:{{ .Version}}"
+- image_templates: [ "ministryofjustice/{{ .ProjectName }}:{{ .Tag}}-amd64"]
+  goarch: amd64
+  dockerfile: '{{ .Env.DOCKERFILE }}'
   use: buildx
-  dockerfile: Dockerfile
+  build_flag_templates:
+  - --platform=linux/amd64
+  - --label=org.opencontainers.image.title={{ .ProjectName }}
+  - --label=org.opencontainers.image.description={{ .ProjectName }}
+  - --label=org.opencontainers.image.url=https://github.com/ministryofjustice/{{ .ProjectName }}
+  - --label=org.opencontainers.image.source=https://github.com/ministryofjustice/{{ .ProjectName }}
+  - --label=org.opencontainers.image.version={{ .Version }}
+  - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+  - --label=org.opencontainers.image.revision={{ .FullCommit }}
+  - --label=org.opencontainers.image.licenses=Apache-2.0 license
+- image_templates: [ "ministryofjustice/{{ .ProjectName }}:{{ .Tag}}-amd64"]
+  goarch: arm64
+  dockerfile: '{{ .Env.DOCKERFILE }}'
+  use: buildx
+  build_flag_templates:
+  - --platform=linux/arm64
+  - --label=org.opencontainers.image.title={{ .ProjectName }}
+  - --label=org.opencontainers.image.description={{ .ProjectName }}
+  - --label=org.opencontainers.image.url=https://github.com/ministryofjustice/{{ .ProjectName }}
+  - --label=org.opencontainers.image.source=https://github.com/ministryofjustice/{{ .ProjectName }}
+  - --label=org.opencontainers.image.version={{ .Version }}
+  - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+  - --label=org.opencontainers.image.revision={{ .FullCommit }}
+  - --label=org.opencontainers.image.licenses=Apache-2.0 license
+docker_manifests:
+- name_template: ministryofjustice/{{ .ProjectName }}:{{ .Tag }}
+  image_templates:
+  - ministryofjustice/{{ .ProjectName }}:{{ .Tag}}-amd64
+  - ministryofjustice/{{ .ProjectName }}:{{ .Tag}}-arm64
+- name_template: ministryofjustice/{{ .ProjectName }}:latest
+  image_templates:
+  - ministryofjustice/{{ .ProjectName }}:{{ .Tag}}-amd64
+  - ministryofjustice/{{ .ProjectName }}:{{ .Tag}}-arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,6 @@ ENV \
 
 WORKDIR /go/bin
 
-# Build linter
-COPY go.mod .
-COPY go.sum .
-RUN go mod download
-COPY . .
+COPY cloud-platform-po-linter /go/bin
 
-RUN go build -ldflags "-s -w" .
-
-CMD ["/go/bin/cloud-platform-po-linter"]
+CMD ["cloud-platform-po-linter"]


### PR DESCRIPTION
Dockerfile doesnt need to build image inside dockerfile when using goreleaser. This was causing the below error. Fix is to just have a dockerfile that copies and executes the binary 
Error: `Error: The process '/opt/hostedtoolcache/goreleaser-action/1.12.3/x64/goreleaser' failed with exit code 1`
Fix: https://goreleaser.com/errors/docker-build/
